### PR TITLE
Buffer() constructors are not recommended

### DIFF
--- a/node.js/1_잔액조회하기.js
+++ b/node.js/1_잔액조회하기.js
@@ -16,7 +16,7 @@ var requestPath = '/balances';
 // 필수 정보를 연결하여 prehash 문자열을 생성함
 var what = nonce + method + requestPath;
 // base64로 secret을 디코딩함
-var key = Buffer(secret, 'base64');
+var key = Buffer.from(secret, 'base64');
 // secret으로 sha512 hmac을 생성함
 var hmac = crypto.createHmac('sha512', key);
 


### PR DESCRIPTION
The Buffer() and new Buffer() constructors are not recommended for use due to security and usability concerns. Please use the new Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() construction methods instead.

https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/